### PR TITLE
example: Adding mirror.yml example

### DIFF
--- a/mirror.yml
+++ b/mirror.yml
@@ -1,0 +1,17 @@
+name: Mirroring
+
+on: [push]
+
+jobs:
+  to_foundries:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: foundriesio/mirror-action@master
+        with:
+          REMOTE: "https://source.foundries.io/factories/<FACTORY-NAME>/containers.git"
+          GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+          PUSH_ALL_REFS: "false"
+          GITHUB_REF: <BRANCH>


### PR DESCRIPTION
This example will be useful for users who want to download an example.

Today we have it just on the README.md

Signed-off-by: Raul Muñoz <raul@foundries.io>