### PR TITLE
add a call to declare the checkout folder a safe directory when inside the container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ fi
 REMOTE=${INPUT_REMOTE:-"$*"}
 GIT_ACCESS_TOKEN=${INPUT_GIT_ACCESS_TOKEN}
 GIT_PUSH_ARGS=${INPUT_GIT_PUSH_ARGS:-"--tags --force"}
+git config --global --add safe.directory /github/workspace
 HAS_CHECKED_OUT="$(git rev-parse --is-inside-work-tree 2>/dev/null || /bin/true)"
 
 


### PR DESCRIPTION
GitHub seems to have made a change that causes this action to fail because the folder used inside the container has a different owner than when the source was checked out outside the container.  

This change flags the internal folder as being safe to use for pushes so that the mirroring operation can complete