### PR TITLE
Update runs-on field for supported OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ on: [push]
 
 jobs:
   to_foundries:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: foundriesio/mirror-action@master

--- a/mirror.yml
+++ b/mirror.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   to_foundries:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
It appears that github support for Ubuntu 18.04 has ended so update the information to run on 20.04.